### PR TITLE
add local file parsing capability to readability CLI

### DIFF
--- a/cmd/readability/README.md
+++ b/cmd/readability/README.md
@@ -11,7 +11,7 @@ go install github.com/mackee/go-readability/cmd/readability@latest
 ## Usage
 
 ```bash
-readability [options] <url>
+readability [options] <url|file_path>
 ```
 
 ### Options
@@ -25,6 +25,11 @@ readability [options] <url>
 Extract content from a URL and output as HTML:
 ```bash
 readability https://example.com/article
+```
+
+Extract content from a local file and output as HTML:
+```bash
+readability ./article.html
 ```
 
 Extract content and output as Markdown:

--- a/cmd/readability/main.go
+++ b/cmd/readability/main.go
@@ -27,7 +27,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	// Get the URL from command-line arguments
+	// Get the URL or file path from command-line arguments
 	src := flag.Arg(0)
 
 	body, err := func() ([]byte, error) {

--- a/cmd/readability/main.go
+++ b/cmd/readability/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -27,10 +28,20 @@ func main() {
 	}
 
 	// Get the URL from command-line arguments
-	url := flag.Arg(0)
+	src := flag.Arg(0)
 
-	// Fetch the content from the URL
-	article, err := fetchAndParse(url)
+	body, err := func() ([]byte, error) {
+		if isRequestURL(src) {
+			return fetchContent(src)
+		}
+		return readFile(src)
+	}()
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Parse the content
+	article, err := parseContent(body)
 	if err != nil {
 		log.Fatalf("Error: %v", err)
 	}
@@ -70,10 +81,14 @@ func main() {
 	}
 }
 
-// fetchAndParse fetches content from a URL and parses it using readability
-func fetchAndParse(url string) (*readability.ReadabilityArticle, error) {
+func isRequestURL(s string) bool {
+	_, err := url.ParseRequestURI(s)
+	return err == nil
+}
+
+func fetchContent(src string) ([]byte, error) {
 	// Fetch the content
-	resp, err := http.Get(url)
+	resp, err := http.Get(src)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch URL: %w", err)
 	}
@@ -92,26 +107,38 @@ func fetchAndParse(url string) (*readability.ReadabilityArticle, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
+	return body, nil
+}
 
+func readFile(src string) ([]byte, error) {
+	// Read the file
+	body, err := os.ReadFile(src)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+	return body, nil
+}
+
+func parseContent(body []byte) (*readability.ReadabilityArticle, error) {
 	// Parse the content
 	options := readability.DefaultOptions()
 	article, err := readability.Extract(string(body), options)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse content: %w", err)
 	}
-
 	return &article, nil
 }
 
 // printUsage prints the usage information
 func printUsage() {
-	fmt.Println("Usage: readability [options] <url>")
+	fmt.Println("Usage: readability [options] <url|file_path>")
 	fmt.Println("\nOptions:")
 	fmt.Println("  --format <format>  Output format: html or markdown (default: html)")
 	fmt.Println("  --metadata         Output metadata as JSON instead of content")
 	fmt.Println("  --help             Show this help message")
 	fmt.Println("\nExamples:")
 	fmt.Println("  readability https://example.com/article")
+	fmt.Println("  readability ./article.html")
 	fmt.Println("  readability --format markdown https://example.com/article")
 	fmt.Println("  readability --metadata https://example.com/article")
 }


### PR DESCRIPTION
* This PR adds local file parsing capability to readability CLI.
  - Reading content from stdin is not included in this change and will be addressed in a separate PR.
* fix: #1